### PR TITLE
Refactored validating rental-dates

### DIFF
--- a/src/main/java/ch/juventus/carrental/model/Rental.java
+++ b/src/main/java/ch/juventus/carrental/model/Rental.java
@@ -1,5 +1,6 @@
 package ch.juventus.carrental.model;
 
+import ch.juventus.carrental.service.DateValidator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Date;
@@ -42,7 +43,7 @@ public class Rental {
 
     @JsonIgnore
     public Boolean isValid(){
-            return startDate != null && endDate != null && startDate.before(endDate);
+        return DateValidator.validate(startDate, endDate);
     }
 
 }

--- a/src/test/java/ch/juventus/carrental/model/RentalTest.java
+++ b/src/test/java/ch/juventus/carrental/model/RentalTest.java
@@ -34,6 +34,18 @@ class RentalTest {
     }
 
     @Test
+    void rentalIsValidWithSameDay() {
+        try{
+            rental.setStartDate(sdf.parse("29.05.2022"));
+            rental.setEndDate(sdf.parse("29.05.2022"));
+
+        } catch (ParseException e) {
+            // This is a unit test. this works :)
+        }
+        assertTrue(rental.isValid());
+    }
+
+    @Test
     void rentalIsInvalid() {
         try{
             rental.setStartDate(sdf.parse("30.05.2022"));


### PR DESCRIPTION
Use DateValidator.validate() to validate dates in Rental-Class
- Also accept date-ranges of same day